### PR TITLE
Fix applyscriptfix loop during BMS install + Option Prompt

### DIFF
--- a/Batch/InstallSourceMods.bat
+++ b/Batch/InstallSourceMods.bat
@@ -98,7 +98,7 @@ echo (update) to update this script.
 echo For the manual install mods, you will need to subscribe to the Mod Support on the workshop to play it in Synergy.
 echo Full Auto installs will install the Mod Support automatically as well.
 rem (RANDD) for Research and Development SUPPORT NOT COMPLETED
-set /p uprun=
+set /p uprun=Option: || (echo Invalid Option && goto start)
 for /f "delims=" %%V in ('powershell -command "$env:uprun.ToLower()"') do set "uprun=%%V"
 if "%uprun%"=="sourcemods" (
 	explorer "%cldir%"
@@ -330,6 +330,7 @@ if NOT EXIST "%steamcmddir%\steamcmd.exe" (
 	if EXIST ..\steamcmd.exe set steamcmddir=..
 )
 if NOT EXIST "%steamcmddir%\steamcmd.exe" (
+	set foundcmd=0
 	set returntostep=1
 	echo ^Failed to find SteamCMD for workshop update/install. Attempting to re-download...
 )


### PR DESCRIPTION
During BMS install, 'applyscriptfix' section was stuck on a loop when steamcmd.exe was not found. This was fixed by setting ´foundcmd=0` after the file exist checks. Added OR comparison to 'set /p uprun=` so that it returns to start immediately if input is blank.